### PR TITLE
Fixed rule ordering

### DIFF
--- a/score/auth/__init__.py
+++ b/score/auth/__init__.py
@@ -24,6 +24,7 @@
 # the discretion of STRG.AT GmbH also the competent court, in whose district the
 # Licensee has his registered seat, an establishment or assets.
 
+from collections import OrderedDict
 import logging
 from score.init import (
     ConfiguredModule, parse_dotted_path, parse_call, parse_list)
@@ -168,12 +169,12 @@ class RuleSet:
         """
         if callable(operation):
             if operation.__name__ not in self.rules:
-                self.rules[operation.__name__] = {}
+                self.rules[operation.__name__] = OrderedDict()
             self.rules[operation.__name__][tuple()] = operation
             return operation
         def capturer(func):
             if operation not in self.rules:
-                self.rules[operation] = {}
+                self.rules[operation] = OrderedDict()
             self.rules[operation][args] = func
             return func
         return capturer


### PR DESCRIPTION
Module was using normal `dict`s for keeping track of the rules,
effectively throwing away the order in which the rules were defined.
Fixed this issue by replacing some `dict` occurrences with `OrderedDict`s.
