### PR TITLE
prevent SessionAuthenticator._load to raise an error when data is None

### DIFF
--- a/score/auth/authenticator.py
+++ b/score/auth/authenticator.py
@@ -74,7 +74,7 @@ class SessionAuthenticator(Authenticator):
         self.dbcls = actor_class
 
     def retrieve(self, ctx):
-        if self.session_key in ctx.session:
+        if self.session_key in ctx.session and ctx.session[self.session_key]:
             return self._load(ctx, ctx.session[self.session_key])
         return self.next.retrieve(ctx)
 


### PR DESCRIPTION
when using score.session.db, and accessing a session with is no longer in the db, the SessionAuthenticator.retrieve function calls the SessionAuthenticator._load with param data=None this cause the orm layer to raise an error.

this little fix prevent the call of SessionAuthenticator._load if data is None.
